### PR TITLE
Set STATUS mode for CMake message() function calls

### DIFF
--- a/cmake/ucm.cmake
+++ b/cmake/ucm.cmake
@@ -244,11 +244,11 @@ endmacro()
 # Prints all compiler flags for all configurations
 macro(ucm_print_flags)
     ucm_gather_flags(1 flags_configs)
-    message("")
+    message(STATUS "")
     foreach(flags ${flags_configs})
-        message("${flags}: ${${flags}}")
+        message(STATUS "${flags}: ${${flags}}")
     endforeach()
-    message("")
+    message(STATUS "")
 endmacro()
 
 # ucm_set_xcode_attrib


### PR DESCRIPTION
Not having a mode causes the message to print to stderr instead of stdout.

There are some setups where anything printed to stderr is considered an error for the purposes of determining if a subprocess worked or not. I recently encountered this problem where messages getting printed to stderr by CMake were causing commands to terminate (on CI builds) -- it seemed to be most problematic when using powershell to run a setuptools build (that compiles a native module using CMake).