### PR TITLE
New useful cmake macro ucm_remove_flags()

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Documentation
 - [ucm_print_flags](#ucm_print_flags)
 - [ucm_add_flags](#ucm_add_flags)
 - [ucm_set_flags](#ucm_set_flags)
+- [ucm_remove_flags](#ucm_remove_flags)
 - [ucm_add_linker_flags](#ucm_add_linker_flags)
 - [ucm_set_linker_flags](#ucm_set_linker_flags)
 - [ucm_set_runtime](#ucm_set_runtime)
@@ -85,6 +86,15 @@ ucm_set_flags(CXX) # will clear CMAKE_CXX_FLAGS
 ucm_set_flags() # will clear both CMAKE_C_FLAGS and CMAKE_CXX_FLAGS
 ucm_set_flags(CXX -O3) # will set CMAKE_CXX_FLAGS
 ucm_set_flags(-O3 -Wall CONFIG Debug) # will set CMAKE_C_FLAGS_DEBUG and CMAKE_CXX_FLAGS_DEBUG
+```
+
+##### <a name="ucm_remove_flags"></a>macro ```ucm_remove_flags([C] [CXX] [CONFIG <config>] flag1 flag2 flag3...)```
+
+Removes the flags from a different set depending on it's options - examples:
+```cmake
+ucm_remove_flags(CXX /EHsc /GR) # will remove from CMAKE_CXX_FLAGS
+ucm_remove_flags(/W3) # will remove from both CMAKE_C_FLAGS and CMAKE_CXX_FLAGS
+ucm_remove_flags(/RTC1 CONFIG Debug) # will remove from CMAKE_C_FLAGS_DEBUG and CMAKE_CXX_FLAGS_DEBUG
 ```
 
 ##### <a name="ucm_add_linker_flags"></a>macro ```ucm_add_linker_flags([EXE] [MODULE] [SHARED] [STATIC] [CONFIG <config>] flag1 flag2 flag3...)```

--- a/cmake/ucm.cmake
+++ b/cmake/ucm.cmake
@@ -77,6 +77,38 @@ macro(ucm_set_flags)
     ucm_add_flags(CLEAR_OLD ${ARGN})
 endmacro()
 
+# ucm_remove_flags
+# Removes compiler flags from CMAKE_<LANG>_FLAGS or from a specific config
+macro(ucm_remove_flags)
+    cmake_parse_arguments(ARG "C;CXX" "" "CONFIG" ${ARGN})
+
+    if(NOT ARG_CONFIG)
+        set(ARG_CONFIG " ")
+    endif()
+
+    foreach(CONFIG ${ARG_CONFIG})
+        # determine from which flags to remove
+        if(NOT ${CONFIG} STREQUAL " ")
+            string(TOUPPER ${CONFIG} CONFIG)
+            set(CXX_FLAGS CMAKE_CXX_FLAGS_${CONFIG})
+            set(C_FLAGS CMAKE_C_FLAGS_${CONFIG})
+        else()
+            set(CXX_FLAGS CMAKE_CXX_FLAGS)
+            set(C_FLAGS CMAKE_C_FLAGS)
+        endif()
+
+        # remove all the passed flags
+        foreach(flag ${ARG_UNPARSED_ARGUMENTS})
+            if("${ARG_CXX}" OR NOT "${ARG_C}")
+                string(REGEX REPLACE "${flag}" "" ${CXX_FLAGS} "${${CXX_FLAGS}}")
+            endif()
+            if("${ARG_C}" OR NOT "${ARG_CXX}")
+                string(REGEX REPLACE "${flag}" "" ${C_FLAGS} "${${C_FLAGS}}")
+            endif()
+        endforeach()
+    endforeach()
+endmacro()
+
 # ucm_add_linker_flags
 # Adds linker flags to CMAKE_<TYPE>_LINKER_FLAGS or to a specific config
 macro(ucm_add_linker_flags)


### PR DESCRIPTION
CMake sets certain flags for MSVC to defaults that we sometimes want to override:
```cmake
ucm_remove_flags(/EHsc /GR)
```

