### PR TITLE
Updated the compatibility for UCM CMake macros

### DIFF
--- a/cmake/ucm.cmake
+++ b/cmake/ucm.cmake
@@ -10,7 +10,7 @@
 # The documentation can be found at the library's page:
 # https://github.com/onqtam/ucm
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5...3.31)
 
 include(CMakeParseArguments)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 2.8.12...3.31)
 
 project(example)
 


### PR DESCRIPTION
Raised the minimum required version of CMake to 3.5, but more importantly indicated the maximum known compatibility to be 3.31, which makes it kind of future-proof.